### PR TITLE
Support for hexadecimal test_mask

### DIFF
--- a/test/dspal_tester/apps_proc/test_mask_utils.c
+++ b/test/dspal_tester/apps_proc/test_mask_utils.c
@@ -43,7 +43,8 @@
 void test_mask_utils_print_help()
 {
   printf("dspal_tester [-h|--help] [test_mask]\n\n");
-  printf("test_mask: string containing 0 in position of disabled tests, 1 in position of enabled tests\n\n");
+  printf("test_mask: binary: string containing 0 in position of disabled tests, 1 in position of enabled tests\n");
+  printf("test_mask:    hex: hex string equivalent to binary test_mask. must begin with 0x\n\n");
   printf("List of tests:\n");
   printf(" 1) test_clockid\n");
   printf(" 2) test_sigevent\n");

--- a/test/dspal_tester/apps_proc/test_mask_utils.c
+++ b/test/dspal_tester/apps_proc/test_mask_utils.c
@@ -100,6 +100,31 @@ void test_mask_utils_print_help()
   printf("53) test_fwrite_fread\n");
 }
 
+void test_mask_utils_process_binary_mask(char test_mask[], char arg[])
+{
+    int i = strlen(arg[i]);
+    if (i != TOTAL_NUM_DSPAL_TESTS)
+    {
+      fprintf(stderr, "Argument error: Test mask is not %d characters long\n\n", TOTAL_NUM_DSPAL_TESTS);
+      test_mask_utils_print_help();
+      return -1;
+    }
+    else
+    {
+      memcpy(test_mask, argv[1], i + 1);
+    }
+}
+
+void test_mask_utils_process_hex_mask(char test_mask[], char arg[])
+{
+    uint arg_as_num = (uint)strtoul(arg, NULL, 0);
+    for (int i = 0; i < TOTAL_NUM_DSPAL_TESTS; i++)
+    {
+        test_mask[i] = ((arg_as_num & 0x1) == 1) ? '1' : '0';
+    }
+    test_mask[i] = '\0';
+}
+
 int test_mask_utils_process_cli_args(int argc, char* argv[], char test_mask[])
 {
   if (argc < 2)
@@ -118,18 +143,14 @@ int test_mask_utils_process_cli_args(int argc, char* argv[], char test_mask[])
   }
   else
   {
-    int i;
-    for (i = 0; argv[1][i] != '\0'; i++);
-    if (i != TOTAL_NUM_DSPAL_TESTS)
-    {
-      fprintf(stderr, "Argument error: Test mask is not %d characters long\n\n", TOTAL_NUM_DSPAL_TESTS);
-      test_mask_utils_print_help();
-      return -1;
-    }
-    else
-    {
-      memcpy(test_mask, argv[1], i + 1);
-    }
+      if ((strlen(argv[1]) >= 3) && argv[1][0] == '0' && argv[1][1] == 'x') /* Begins with 0x */
+      {
+          test_mask_utils_process_hex_mask(test_mask, argv[1]);
+      }
+      else
+      {
+          test_mask_utils_process_binary_mask(test_mask, argv[1]);
+      }
   }
   return 0;
 }

--- a/test/dspal_tester/apps_proc/test_mask_utils.c
+++ b/test/dspal_tester/apps_proc/test_mask_utils.c
@@ -101,7 +101,7 @@ void test_mask_utils_print_help()
   printf("53) test_fwrite_fread\n");
 }
 
-void test_mask_utils_process_binary_mask(char test_mask[], char arg[])
+int test_mask_utils_process_binary_mask(char test_mask[], char arg[])
 {
     int i = strlen(arg[i]);
     if (i != TOTAL_NUM_DSPAL_TESTS)
@@ -114,6 +114,8 @@ void test_mask_utils_process_binary_mask(char test_mask[], char arg[])
     {
       memcpy(test_mask, argv[1], i + 1);
     }
+
+    return 0;
 }
 
 void test_mask_utils_process_hex_mask(char test_mask[], char arg[])
@@ -150,7 +152,7 @@ int test_mask_utils_process_cli_args(int argc, char* argv[], char test_mask[])
       }
       else
       {
-          test_mask_utils_process_binary_mask(test_mask, argv[1]);
+          return test_mask_utils_process_binary_mask(test_mask, argv[1]);
       }
   }
   return 0;


### PR DESCRIPTION
Feature for dspal_tester allowing user to supply test selection mask in binary or hex. Previously only supported binary strings. Hex strings can be supplied prepended with "0x".

**WARNING: This code is untested on target as I don't have those boards.**
