### PR TITLE
Modified dspal_tester for the aDSP to use a different SPI port

### DIFF
--- a/test/dspal_tester/adsp_proc/spi_test_imp.c
+++ b/test/dspal_tester/adsp_proc/spi_test_imp.c
@@ -401,10 +401,17 @@ int dspal_tester_spi_test(void)
 		LOG_ERR("error: spi exceed max write length test failed: %d", result);
 		return result;
 	}
+
+// This test is disabled for the ADSP since it causes conflicts with the serial I/O test
+// when executed multiple times in succession.  This is most likely
+// related to a known issue with the serial driver which must remain
+// open even after the close function is executed.
+#if defined(DSP_TYPE_SLPI)
 	LOG_INFO("beginning whoami test");
 	if ((result = dspal_tester_spi_whoami_test()) < SUCCESS) {
 		LOG_ERR("error: spi whoami test failed: %d", result);
 		return result;
 	}
+#endif
 	return SUCCESS;
 }

--- a/test/include/platform.h
+++ b/test/include/platform.h
@@ -31,9 +31,12 @@
  ****************************************************************************/
 
 #pragma once
-
-// SPI port definition for the board
+#if defined(DSP_TYPE_ADSP)
+// Use spi-8 on the ADSP to avoid conflicts with the serial I/O tests.
+#define SPI_DEVICE_PATH "/dev/spi-8"
+#elif defined(DSP_TYPE_SLPI)
 #define SPI_DEVICE_PATH "/dev/spi-1"
+#endif
 
 // I2C port definition
 #if defined(DSP_TYPE_ADSP)


### PR DESCRIPTION
This change is required to prevent conflicts with the serial port tests when dspal_tester is run a second time in succession.